### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program to help with college applications",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary
This PR adds the missing GitHub Skills activity that was announced by the principal in the school assembly.

## Changes
- Added "GitHub Skills" to the activities list in `src/app.py`
- Description highlights the GitHub Certifications program for college applications
- Schedule: Wednesdays, 3:30 PM - 5:00 PM
- Capacity: 25 students
- Ready for student registration

## Fixes
Closes #6

## Testing
- Activity is now available in the system
- Students can register for GitHub Skills before the end-of-week deadline